### PR TITLE
Allowed for custom server home dir

### DIFF
--- a/fn_utilities/fn_utilities/components/utilities_restart_circuits
+++ b/fn_utilities/fn_utilities/components/utilities_restart_circuits
@@ -41,29 +41,34 @@ class FunctionComponent(ResilientComponent):
 
         try:
             # Get the function parameters:
+            home_dir = kwargs.get("home_dir")  # string
             circuits_service_name = kwargs.get("circuits_service_name")  # string
             reboot_server = kwargs.get("reboot_server")  # boolean
             
             if circuits_service_name is None:
               circuits_service_name = 'resilient_circuits.service'
 
-            if os.path.exists('/home/integrations/.resilient/rc_restarted.lock') is False:
-                open('/home/integrations/.resilient/rc_restarted.lock', 'w+').close()
-                if os.path.exists('/home/integrations/.resilient/rc_restarted.lock') is False: raise IOError
+            if home_dir is None:
+                home_dir = r'/home/integration'
+
+
+            if os.path.exists(home_dir + r'/.resilient/rc_restarted.lock') is False:
+                open(home_dir + r'/.resilient/rc_restarted.lock', 'w+').close()
+                if os.path.exists(home_dir + r'/.resilient/rc_restarted.lock') is False: raise IOError
                 if reboot_server is True:
-                    yield StatusMessage('[INFO] Rebooting the Resilient integrations server...')
+                    yield StatusMessage('[INFO] Rebooting the Resilient integration server...')
                     os.system('reboot')
                 else:
                     yield StatusMessage('[INFO] Restarting the Resilient Circuits service...')
                     os.system("sudo systemctl restart " + circuits_service_name)  # Modify if service not managed via systemctl
 
             else:
-                os.remove('/home/integrations/.resilient/rc_restarted.lock')
+                os.remove('home_dir + r'/.resilient/rc_restarted.lock')
                 if reboot_server is True: yield StatusMessage('[SUCCESS] Reboot completed!')
                 else: yield StatusMessage('[SUCCESS] Restart completed!')
 
         except Exception as err:  # Catch all exceptions and abort
-            try: os.remove('/home/integrations/.resilient/rc_restarted.lock')
+            try: os.remove('home_dir + r'/.resilient/rc_restarted.lock')
             except: pass
             yield StatusMessage('[FATAL ERROR] Encountered: ' + str(err))
             yield StatusMessage('[FAILURE] Fatal error caused exit!')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->
This new utility script has the ability to restart the Resilient Circuits service or the entire integration server. This may be useful for customers who wish to push function updates in-product.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Useful function for pushing Resilient changes with ease without establishing a shell session to the integration server. Useful for Resilient Devs / CyberSec engineers.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have used this function in production since last year without issue. The function creates a lock file to establish state persistence across the RC restart. IBM Resilient Engineering will need to add function and base workflow to the fn_utilties customize.py script.
<!--- If this PR does not contain a new test case, explain why. -->
IBM Resilient Engineering could implement a formal test if desired.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/IBMResilient/resilient-community-apps/blob/master/CONTRIBUTING.md)
- [] Either no new documentation is required by this change, OR I added new documentation
- [] Either no new tests are required by this change, OR I added new tests
- [] I have run pep8 and pylint. I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jared Fagel, jfagel[@]allete[.]com - Email with questions, providing base function for Engineering team to consider.
